### PR TITLE
Modified user query to show user SAMAccountName

### DIFF
--- a/UserTool.ps1
+++ b/UserTool.ps1
@@ -51,10 +51,10 @@ function Get_UserList {
     if (!$lastname) {
         $lastname = "*"
     }
+    #print list of each entry in Active Directory based on the above search parameters
     foreach ($userList in (Get-ADUser -Filter { (givenname -like $firstname -and surname -like $lastname) })) {
         $menuArray += , $userList
-        Write-host "$userCounter. $($menuArray[$userCounter-1].givenname); $($menuArray[$userCounter-1].surname)"
-        #Write-Host "$userCounter. $($userList[$userCounter-1].SamAccountName); $($userList[$userCounter-1].givenname) $($userList[$userCounter-1].surname)"
+        Write-host "$userCounter. $($menuArray[$userCounter-1].givenname) $($menuArray[$userCounter-1].surname), $($menuArray[$userCounter-1].SamAccountName)"
         $userCounter++
     }
 


### PR DESCRIPTION
Improved the query by showing SAMAccountName as well as givenname and surname.  This helps differentiate instances where there are multiple people with the same givenname and surname like "John Smith" or in cases where a person has two accounts like a user account and an admin account.